### PR TITLE
add z-index:1 to zero-width-trigger-fix, fix issue 17160

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -1876,7 +1876,8 @@ form .ant-upload {
 .ant-layout-sider-zero-width-trigger {
     background: #404040;
     color: #fff;
-    border-radius: 0 4px 4px 0
+    border-radius: 0 4px 4px 0;
+    z-index: 1;
 }
 .ant-layout-sider-zero-width-trigger:hover {
     background: #535353


### PR DESCRIPTION
Due to issue [Layout.Sider‘s zero-width trigger stacked too low #17160](https://github.com/ant-design/ant-design/issues/17160), this can be a solution.